### PR TITLE
Add entities

### DIFF
--- a/anvil/__init__.py
+++ b/anvil/__init__.py
@@ -1,7 +1,9 @@
 from .block import Block, OldBlock
+from .entity import Entity
 from .chunk import Chunk
 from .empty_chunk import EmptyChunk
 from .empty_region import EmptyRegion
 from .empty_section import EmptySection
+from .empty_entities import EmptyEntities
 from .raw_section import RawSection
 from .region import Region

--- a/anvil/empty_entities.py
+++ b/anvil/empty_entities.py
@@ -1,0 +1,207 @@
+import math
+import zlib
+from io import BytesIO
+from typing import BinaryIO, List, Union
+
+from .empty_entities_chunk import EmptyEntitiesChunk
+from .errors import OutOfBoundsCoordinates
+
+from .constants import YMIN, YMAX
+
+
+def from_inclusive(a, b):
+    """Returns a range from a to b, including both endpoints"""
+    c = int(b > a) * 2 - 1
+    return range(a, b + c, c)
+
+
+class EmptyEntities:
+    """
+    Used for making own entities
+
+    Attributes
+    ----------
+    chunks: List[:class:`anvil.EmptyEntitiesChunk`]
+        List of chunks in this region
+    x: :class:`int`
+    z: :class:`int`
+    """
+
+    __slots__ = ("entities_chunks", "x", "z")
+
+    def __init__(self, x: int, z: int):
+        # Create a 1d list for the 32x32 chunks
+        self.entities_chunks: List[EmptyEntitiesChunk] = [None] * 1024
+        self.x = x
+        self.z = z
+
+    def inside(self, x: int, y: int, z: int, chunk: bool = False) -> bool:
+        """
+        Returns if the given coordinates are inside this region
+
+        Parameters
+        ----------
+        x
+            The x coordinate
+        y
+            The y coordinate
+        z
+            The z coordinate
+        chunk
+            Whether coordinates are global or chunk coordinates
+        """
+        factor = 32 if chunk else 512
+        rx = x // factor
+        rz = z // factor
+        return not (rx != self.x or rz != self.z or y < YMIN or y > YMAX)
+
+    def get_chunk(self, x: int, z: int) -> EmptyEntitiesChunk:
+        """
+        Returns the chunk at given chunk coordinates
+
+        Parameters
+        ----------
+        int x, z
+            Chunk's coordinates
+
+        Raises
+        ------
+        anvil.OutOfBoundCoordidnates
+            If the chunk (x, z) is not inside this region
+
+        :rtype: :class:`anvil.EmptyEntitiesChunk`
+        """
+        if not self.inside(x, 0, z, chunk=True):
+            raise OutOfBoundsCoordinates(f"Chunk ({x}, {z}) is not inside this region")
+        return self.entities_chunks[z % 32 * 32 + x % 32]
+
+    def add_chunk(self, chunk: EmptyEntitiesChunk):
+        """
+        Adds given chunk to this region.
+        Will overwrite if a chunk already exists in this location
+
+        Parameters
+        ----------
+        chunk: :class:`EmptyEntitiesChunk`
+
+        Raises
+        ------
+        anvil.OutOfBoundCoordidnates
+            If the chunk (x, z) is not inside this region
+        """
+        if not self.inside(chunk.x, 0, chunk.z, chunk=True):
+            raise OutOfBoundsCoordinates(
+                f"Chunk ({chunk.x}, {chunk.z}) is not inside this region"
+            )
+        self.entities_chunks[chunk.z % 32 * 32 + chunk.x % 32] = chunk
+
+    def add_entity(self, entity_id: str, x: int, y: int, z: int, entity_properties: dict = None):
+        """
+        Sets entity at given coordinates.
+        New chunk is made if it doesn't exist.
+
+        Parameters
+        ----------
+        entity: :class:`Entity`
+            Entity to place
+        x
+            The x coordinate
+        y
+            The y coordinate
+        z
+            The z coordinate
+
+        Raises
+        ------
+        anvil.OutOfBoundsCoordinates
+            If the entity (x, y, z) is not inside this region
+        """
+
+        chunk_x = x % 512
+        chunk_z = z % 512
+        if not self.inside(chunk_x, y, chunk_z):
+            raise OutOfBoundsCoordinates(
+                f"Entity ({x}, {y}, {z}) is not inside this region"
+            )
+        cx = chunk_x // 16
+        cz = chunk_z // 16
+        chunk = self.get_chunk(cx, cz)
+        if chunk is None:
+            chunk = EmptyEntitiesChunk(cx, cz)
+            self.add_chunk(chunk)
+        chunk.add_entity(entity_id, x, y, z, entity_properties)
+
+    def save(self, file: Union[str, BinaryIO] = None) -> bytes:
+        """
+        Returns the region as bytes with
+        the anvil file format structure,
+        aka the final ``.mca`` file.
+
+        Parameters
+        ----------
+        file
+            Either a path or a file object, if given region
+            will be saved there.
+        """
+        # Store all the chunks data as zlib compressed nbt data
+        chunks_data = []
+        for chunk in self.entities_chunks:
+            if chunk is None:
+                chunks_data.append(None)
+                continue
+            chunk_data = BytesIO()
+            nbt_data = chunk.save()
+            nbt_data.write_file(buffer=chunk_data)
+            chunk_data.seek(0)
+            chunk_data = zlib.compress(chunk_data.read())
+            chunks_data.append(chunk_data)
+
+        # This is what is added after the location and timestamp header
+        chunks_bytes = bytes()
+        offsets = []
+        for chunk in chunks_data:
+            if chunk is None:
+                offsets.append(None)
+                continue
+            # 4 bytes are for length, b'\x02' is the compression type which is 2 since its using zlib
+            to_add = (len(chunk) + 1).to_bytes(4, "big") + b"\x02" + chunk
+
+            # offset in 4KiB sectors
+            sector_offset = len(chunks_bytes) // 4096
+            sector_count = math.ceil(len(to_add) / 4096)
+            offsets.append((sector_offset, sector_count))
+
+            # Padding to be a multiple of 4KiB long
+            to_add += bytes(4096 - (len(to_add) % 4096))
+            chunks_bytes += to_add
+
+        locations_header = bytes()
+        for offset in offsets:
+            # None means the chunk is not an actual chunk in the region
+            # and will be 4 null bytes, which represents non-generated chunks to minecraft
+            if offset is None:
+                locations_header += bytes(4)
+            else:
+                # offset is (sector offset, sector count)
+                locations_header += (offset[0] + 2).to_bytes(3, "big") + offset[
+                    1
+                ].to_bytes(1, "big")
+
+        # Set them all as 0
+        timestamps_header = bytes(4096)
+
+        final = locations_header + timestamps_header + chunks_bytes
+
+        # Pad file to be a multiple of 4KiB in size
+        # as Minecraft only accepts region files that are like that
+        final += bytes(4096 - (len(final) % 4096))
+        assert len(final) % 4096 == 0  # just in case
+
+        # Save to a file if it was given
+        if file:
+            if isinstance(file, str):
+                with open(file, "wb") as f:
+                    f.write(final)
+            else:
+                file.write(final)
+        return final

--- a/anvil/empty_entities_chunk.py
+++ b/anvil/empty_entities_chunk.py
@@ -2,10 +2,8 @@ from typing import List
 
 from nbt import nbt
 
-from .block import Block
 from .entity import Entity
 from .empty_section import EmptySection
-from .errors import EmptySectionAlreadyExists, OutOfBoundsCoordinates
 
 from .constants import YMIN, YMAX, NSECTIONS
 
@@ -35,98 +33,6 @@ class EmptyEntitiesChunk:
         self.version = 1976
         self.entities: List[Entity] = []
 
-    def add_section(self, section: EmptySection, replace: bool = True):
-        """
-        Adds a section to the chunk
-
-        Parameters
-        ----------
-        section
-            Section to add
-        replace
-            Whether to replace section if one at same Y already exists
-
-        Raises
-        ------
-        anvil.EmptySectionAlreadyExists
-            If ``replace`` is ``False`` and section with same Y already exists in this chunk
-        """
-        if self.sections[section.y] and not replace:
-            raise EmptySectionAlreadyExists(
-                f"EmptySection (Y={section.y}) already exists in this chunk"
-            )
-        self.sections[section.y] = section
-
-    def get_block(self, x: int, y: int, z: int) -> Block:
-        """
-        Gets the block at given coordinates
-
-        Parameters
-        ----------
-        x
-            In range of 0 to 15
-        y
-            In range of 0 to 255
-        z
-            In range of 0 to 15
-
-        Raises
-        ------
-        anvil.OutOfBoundCoordidnates
-            If X, Y or Z are not in the proper range
-
-        Returns
-        -------
-        block : :class:`anvil.Block` or None
-            Returns ``None`` if the section is empty, meaning the block
-            is most likely an air block.
-        """
-        if x < 0 or x > 15:
-            raise OutOfBoundsCoordinates(f"X ({x!r}) must be in range of 0 to 15")
-        if z < 0 or z > 15:
-            raise OutOfBoundsCoordinates(f"Z ({z!r}) must be in range of 0 to 15")
-        if y < YMIN or y > YMAX:
-            raise OutOfBoundsCoordinates(f'Y ({y!r}) must be in range of {YMIN} to {YMAX}')
-
-        section = self.sections[y // 16]
-
-        if section is None:
-            return
-
-        return section.get_block(x, y % 16, z)
-
-    def set_block(self, block: Block, x: int, y: int, z: int):
-        """
-        Sets block at given coordinates
-
-        Parameters
-        ----------
-        block
-            The block to set
-        x
-            In range of 0 to 15
-        y
-            In range of 0 to 255
-        z
-            In range of 0 to 15
-
-        Raises
-        ------
-        anvil.OutOfBoundCoordidnates
-            If X, Y or Z are not in the proper range
-
-        """
-        if x < 0 or x > 15:
-            raise OutOfBoundsCoordinates(f"X ({x!r}) must be in range of 0 to 15")
-        if z < 0 or z > 15:
-            raise OutOfBoundsCoordinates(f"Z ({z!r}) must be in range of 0 to 15")
-        if y < YMIN or y > YMAX:
-            raise OutOfBoundsCoordinates(f'Y ({y!r}) must be in range of {YMIN} to {YMAX}')
-        section = self.sections[y // 16]
-        if section is None:
-            section = EmptySection(y // 16)
-            self.add_section(section)
-        section.set_block(block, x, y % 16, z)
 
     def add_entity(self, entity_id: str, x: int, y: int, z: int, entity_properties: dict = None):
         print('chunk.py: set_entity', entity_id, x, y, z)

--- a/anvil/empty_entities_chunk.py
+++ b/anvil/empty_entities_chunk.py
@@ -1,0 +1,175 @@
+from typing import List
+
+from nbt import nbt
+
+from .block import Block
+from .entity import Entity
+from .empty_section import EmptySection
+from .errors import EmptySectionAlreadyExists, OutOfBoundsCoordinates
+
+from .constants import YMIN, YMAX, NSECTIONS
+
+
+class EmptyEntitiesChunk:
+    """
+    Used for making own chunks
+
+    Attributes
+    ----------
+    x: :class:`int`
+        Chunk's X position
+    z: :class:`int`
+        Chunk's Z position
+    sections: List[:class:`anvil.EmptySection`]
+        List of all the sections in this chunk
+    version: :class:`int`
+        Chunk's DataVersion
+    """
+
+    __slots__ = ("x", "z", "sections", "version", "entities")
+
+    def __init__(self, x: int, z: int):
+        self.x = x
+        self.z = z
+        self.sections: List[EmptySection] = [None] * NSECTIONS
+        self.version = 1976
+        self.entities: List[Entity] = []
+
+    def add_section(self, section: EmptySection, replace: bool = True):
+        """
+        Adds a section to the chunk
+
+        Parameters
+        ----------
+        section
+            Section to add
+        replace
+            Whether to replace section if one at same Y already exists
+
+        Raises
+        ------
+        anvil.EmptySectionAlreadyExists
+            If ``replace`` is ``False`` and section with same Y already exists in this chunk
+        """
+        if self.sections[section.y] and not replace:
+            raise EmptySectionAlreadyExists(
+                f"EmptySection (Y={section.y}) already exists in this chunk"
+            )
+        self.sections[section.y] = section
+
+    def get_block(self, x: int, y: int, z: int) -> Block:
+        """
+        Gets the block at given coordinates
+
+        Parameters
+        ----------
+        x
+            In range of 0 to 15
+        y
+            In range of 0 to 255
+        z
+            In range of 0 to 15
+
+        Raises
+        ------
+        anvil.OutOfBoundCoordidnates
+            If X, Y or Z are not in the proper range
+
+        Returns
+        -------
+        block : :class:`anvil.Block` or None
+            Returns ``None`` if the section is empty, meaning the block
+            is most likely an air block.
+        """
+        if x < 0 or x > 15:
+            raise OutOfBoundsCoordinates(f"X ({x!r}) must be in range of 0 to 15")
+        if z < 0 or z > 15:
+            raise OutOfBoundsCoordinates(f"Z ({z!r}) must be in range of 0 to 15")
+        if y < YMIN or y > YMAX:
+            raise OutOfBoundsCoordinates(f'Y ({y!r}) must be in range of {YMIN} to {YMAX}')
+
+        section = self.sections[y // 16]
+
+        if section is None:
+            return
+
+        return section.get_block(x, y % 16, z)
+
+    def set_block(self, block: Block, x: int, y: int, z: int):
+        """
+        Sets block at given coordinates
+
+        Parameters
+        ----------
+        block
+            The block to set
+        x
+            In range of 0 to 15
+        y
+            In range of 0 to 255
+        z
+            In range of 0 to 15
+
+        Raises
+        ------
+        anvil.OutOfBoundCoordidnates
+            If X, Y or Z are not in the proper range
+
+        """
+        if x < 0 or x > 15:
+            raise OutOfBoundsCoordinates(f"X ({x!r}) must be in range of 0 to 15")
+        if z < 0 or z > 15:
+            raise OutOfBoundsCoordinates(f"Z ({z!r}) must be in range of 0 to 15")
+        if y < YMIN or y > YMAX:
+            raise OutOfBoundsCoordinates(f'Y ({y!r}) must be in range of {YMIN} to {YMAX}')
+        section = self.sections[y // 16]
+        if section is None:
+            section = EmptySection(y // 16)
+            self.add_section(section)
+        section.set_block(block, x, y % 16, z)
+
+    def add_entity(self, entity_id: str, x: int, y: int, z: int, entity_properties: dict = None):
+        print('chunk.py: set_entity', entity_id, x, y, z)
+        """
+        Sets entity at given coordinates
+
+        Parameters
+        ----------
+        entity
+            The entity to set
+        x
+        y
+        z
+
+        """
+
+        entity: Entity = Entity(entity_id, x, y, z, entity_properties)
+        self.entities.append(entity)
+
+
+    def save(self) -> nbt.NBTFile:
+        print('chunk.save')
+        """
+        Saves the chunk data to a :class:`NBTFile`
+
+        Notes
+        -----
+        Does not contain most data a regular chunk would have,
+        but minecraft stills accept it.
+        """
+        root = nbt.NBTFile()
+
+
+        position = nbt.TAG_Int_Array(name="Position")
+        position.value = [self.x, self.z]
+        root.tags.extend([
+                nbt.TAG_Int(name="DataVersion", value=self.version),
+                position
+        ])
+        entities = nbt.TAG_List(name="Entities", type=nbt.TAG_Compound)
+
+        for entity in self.entities:
+            entities.tags.append(entity.save())
+
+        root.tags.append(entities)
+        return root

--- a/anvil/empty_entities_chunk.py
+++ b/anvil/empty_entities_chunk.py
@@ -35,7 +35,6 @@ class EmptyEntitiesChunk:
 
 
     def add_entity(self, entity_id: str, x: int, y: int, z: int, entity_properties: dict = None):
-        print('chunk.py: set_entity', entity_id, x, y, z)
         """
         Sets entity at given coordinates
 
@@ -54,7 +53,6 @@ class EmptyEntitiesChunk:
 
 
     def save(self) -> nbt.NBTFile:
-        print('chunk.save')
         """
         Saves the chunk data to a :class:`NBTFile`
 

--- a/anvil/entity.py
+++ b/anvil/entity.py
@@ -1,0 +1,89 @@
+from frozendict import frozendict
+from nbt import nbt
+
+from .legacy import LEGACY_ID_MAP
+
+
+class Entity:
+    """
+    Represents a minecraft entity.
+
+    Attributes
+    ----------
+    id: :class:`str`
+        ID of the entity, for example: minecraft:villager
+    properties: :class:`dict`
+        Entity properties as a dict
+    """
+
+    __slots__ = ("entity_id", "x", "y", "z", "properties")
+
+    def __init__(self, entity_id: str, x: int, y: int, z: int, properties: dict = None):
+        """
+        Parameters
+        ----------
+        entity_id
+            ID of the entity
+        properties
+            Entity properties
+        """
+        self.entity_id = entity_id
+        self.properties = properties or {}
+        self.x, self.y, self.z = x, y, z
+        print('my properties are', self.properties)
+
+    def name(self) -> str:
+        return self.entity_id
+
+    def __repr__(self):
+        return f"Entity({self.name()})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Entity):
+            return False
+        return (
+            self.entity_id == other.id
+            and self.properties == other.properties
+        )
+
+    def __hash__(self):
+        return hash(self.name()) ^ hash(frozendict(self.properties))
+
+
+    def save(self):
+        new_entity = nbt.TAG_Compound()
+        new_entity.tags.append(nbt.TAG_String(name="id", value=self.entity_id))
+
+
+        position = nbt.TAG_List(name="Pos", type=nbt.TAG_Double)
+        position.tags.append(nbt.TAG_Double(self.x))
+        position.tags.append(nbt.TAG_Double(self.y))
+        position.tags.append(nbt.TAG_Double(self.z))
+
+        new_entity.tags.append(position)
+
+        for key, value in self.properties.items():
+            print('entity.py: processing', key, value)
+            if isinstance(value, str):
+                new_entity.tags.append(nbt.TAG_String(name=key, value=value))
+            elif isinstance(value, int):
+                new_entity.tags.append(nbt.TAG_Int(name=key, value=value))
+            elif isinstance(value, float):
+                new_entity.tags.append(nbt.TAG_Float(name=key, value=value))
+            elif isinstance(value, bool):
+                new_entity.tags.append(nbt.TAG_Byte(name=key, value=value))
+            elif isinstance(value, list):
+                if isinstance(value[0], str):
+                    new_list = nbt.TAG_List(name=key, type=nbt.TAG_String)
+                    for i in value:
+                        new_list.tags.append(nbt.TAG_String(i))
+                elif isinstance(value[0], float):
+                    new_list = nbt.TAG_List(name=key, type=nbt.TAG_Float)
+                    for i in value:
+                        new_list.tags.append(nbt.TAG_Float(i))
+                new_entity.tags.append(new_list)
+            else:
+                raise TypeError(f"Unknown type {type(value)} for {key}={value}")
+
+        print('entity.py: save', new_entity)
+        return new_entity

--- a/anvil/entity.py
+++ b/anvil/entity.py
@@ -30,7 +30,6 @@ class Entity:
         self.entity_id = entity_id
         self.properties = properties or {}
         self.x, self.y, self.z = x, y, z
-        print('my properties are', self.properties)
 
     def name(self) -> str:
         return self.entity_id
@@ -63,7 +62,6 @@ class Entity:
         new_entity.tags.append(position)
 
         for key, value in self.properties.items():
-            print('entity.py: processing', key, value)
             if isinstance(value, str):
                 new_entity.tags.append(nbt.TAG_String(name=key, value=value))
             elif isinstance(value, int):
@@ -85,5 +83,4 @@ class Entity:
             else:
                 raise TypeError(f"Unknown type {type(value)} for {key}={value}")
 
-        print('entity.py: save', new_entity)
         return new_entity


### PR DESCRIPTION
Allows you to save entities to the `entities` folder in the minecraft save folder.

It's a little odd, as entities are stored in regional anvil files, with a `nbt` for each chunk within that region. But the coordinates of the entity are absolute world coordinates. (incidentally https://github.com/HubTou/MCA2NBT and  https://nbt.mcph.to/ are useful to view these)

There's probably a better way to code this, so happy if you want to consider this a spike, and refactor it!