### PR TITLE
Add support for more gzip and uncompressed chunks

### DIFF
--- a/anvil/errors.py
+++ b/anvil/errors.py
@@ -13,5 +13,15 @@ class EmptySectionAlreadyExists(Exception):
     """
 
 
-class GZipChunkData(Exception):
+class ChunkCompressionException(Exception):
+    """Generic exception for issues related to chunk compression"""
+
+class GZipChunkData(ChunkCompressionException):
     """Exception used when trying to get chunk data compressed in gzip"""
+
+class UnknownCompressionSchema(ChunkCompressionException):
+    """Raised when a custom exception (id 127) is encountered post 24w05a"""
+    
+    def __init__(self, compression: int):
+        custom_message = "(Id 127 indicates custom compression)" if compression == 127 else ""
+        super().__init__(f"Encountered unknown compression schema {compression} {custom_message}")


### PR DESCRIPTION
The goal of this pull request is to add support for region files compressed using compression formats besides zlib.

Currently support for gzip compression (type 1) and uncompressed regions (type 3) has been implemented. Out of those type 3 has already been shown to work in one test case. Further testing is required before this pull request can be merged.

Additionally there is room for discussing the support of lz4 compression as per recent snapshot [24w04a](https://www.minecraft.net/de-de/article/minecraft-snapshot-24w04a). However there is currently no support for this compression scheme in Python's stdlib so adding of a new dependency would be required. However it is expectable that this new scheme will be employed by especially high-population servers due to its better performance.


This pull request is a draft since some features have not been properly tested.